### PR TITLE
Intergration with HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ aim_1b   = torch.hub.load("apple/ml-aim", "aim_1B")
 aim_3b   = torch.hub.load("apple/ml-aim", "aim_3B")
 aim_7b   = torch.hub.load("apple/ml-aim", "aim_7B")
 ```
+or via [HuggingFace Hub](https://huggingface.co/docs/hub/) as:
+```python
+from aim.torch.models import AIMForImageClassification
+
+aim_600m = AIMForImageClassification.from_pretrained("apple/aim-600M")
+aim_1b   = AIMForImageClassification.from_pretrained("apple/aim-1B")
+aim_3b   = AIMForImageClassification.from_pretrained("apple/aim-3B")
+aim_7b   = AIMForImageClassification.from_pretrained("apple/aim-7B")
+```
+
 
 ### Pre-trained backbones
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ inp = jnp.array(inp)
 ```
 </details>
 
-
 ## Pre-trained checkpoints
 
 The pre-trained models can be accessed via [PyTorch Hub](https://pytorch.org/hub/) as:
@@ -102,7 +101,6 @@ aim_1b   = AIMForImageClassification.from_pretrained("apple/aim-1B")
 aim_3b   = AIMForImageClassification.from_pretrained("apple/aim-3B")
 aim_7b   = AIMForImageClassification.from_pretrained("apple/aim-7B")
 ```
-
 
 ### Pre-trained backbones
 

--- a/aim/torch/models.py
+++ b/aim/torch/models.py
@@ -3,7 +3,9 @@
 # --------------------------------------------------
 # References:
 # https://github.com/facebookresearch/ImageBind
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from huggingface_hub import PyTorchModelHubMixin
 
 import torch
 from torch import nn
@@ -11,7 +13,15 @@ from torch import nn
 from .. import mixins
 from . import layers
 
-__all__ = ["Transformer", "AIM", "aim_600M", "aim_1B", "aim_3B", "aim_7B"]
+__all__ = [
+    "Transformer",
+    "AIM",
+    "AIMForImageClassification",
+    "aim_600M",
+    "aim_1B",
+    "aim_3B",
+    "aim_7B",
+]
 
 
 class Transformer(nn.Module):
@@ -95,6 +105,12 @@ class AIM(mixins.AIMMixin, nn.Module):
         self.head = head
 
 
+class AIMForImageClassification(mixins.AIMMixin, PyTorchModelHubMixin, nn.Module):
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__()
+        self.preprocessor, self.trunk, self.head = _aim(**config)
+
+
 def _get_attention_target(dim: int, num_heads: int) -> Callable[[bool], nn.Module]:
     def callback(use_bias: bool) -> nn.Module:
         return layers.Attention(dim=dim, num_heads=num_heads, use_bias=use_bias)
@@ -112,7 +128,7 @@ def _aim(
     probe_layers: Union[int, Tuple[int, ...]] = 6,
     num_classes: int = 1000,
     **kwargs: Any,
-) -> AIM:
+) -> Tuple[nn.Module, nn.Module, nn.Module]:
     # common
     norm_layer = layers.LayerNorm
 
@@ -154,52 +170,60 @@ def _aim(
         num_queries=1,
     )
 
-    return AIM(preprocessor, trunk, head)
+    return preprocessor, trunk, head
 
 
 def aim_600M(img_size: Union[int, Tuple[int, int]] = 224, **kwargs: Any) -> AIM:
-    return _aim(
-        img_size=img_size,
-        patch_size=14,
-        embed_dim=1536,
-        num_blocks=24,
-        num_heads=12,
-        **kwargs,
+    return AIM(
+        *_aim(
+            img_size=img_size,
+            patch_size=14,
+            embed_dim=1536,
+            num_blocks=24,
+            num_heads=12,
+            **kwargs,
+        )
     )
 
 
 def aim_1B(img_size: Union[int, Tuple[int, int]] = 224, **kwargs: Any) -> AIM:
-    return _aim(
-        img_size=img_size,
-        patch_size=14,
-        embed_dim=2048,
-        num_blocks=24,
-        num_heads=16,
-        **kwargs,
+    return AIM(
+        *_aim(
+            img_size=img_size,
+            patch_size=14,
+            embed_dim=2048,
+            num_blocks=24,
+            num_heads=16,
+            **kwargs,
+        )
     )
 
 
 def aim_3B(
     img_size: Union[int, Tuple[int, int]] = 224, patch_size: int = 14, **kwargs: Any
 ) -> AIM:
-    return _aim(
-        img_size=img_size,
-        patch_size=patch_size,
-        embed_dim=3072,
-        num_blocks=24,
-        num_heads=24,
-        **kwargs,
+    return AIM(
+        *_aim(
+            img_size=img_size,
+            patch_size=patch_size,
+            embed_dim=3072,
+            num_blocks=24,
+            num_heads=24,
+            **kwargs,
+        )
     )
 
 
 def aim_7B(
     img_size: Union[int, Tuple[int, int]] = 224, patch_size: int = 14, **kwargs: Any
 ) -> AIM:
-    return _aim(
-        img_size=img_size,
-        patch_size=patch_size,
-        embed_dim=4096,
-        num_blocks=32,
-        num_heads=32,
-        **kwargs,
+    return AIM(
+        *_aim(
+            img_size=img_size,
+            patch_size=patch_size,
+            embed_dim=4096,
+            num_blocks=32,
+            num_heads=32,
+            **kwargs,
+        )
     )

--- a/aim/torch/models.py
+++ b/aim/torch/models.py
@@ -174,56 +174,52 @@ def _aim(
 
 
 def aim_600M(img_size: Union[int, Tuple[int, int]] = 224, **kwargs: Any) -> AIM:
-    return AIM(
-        *_aim(
-            img_size=img_size,
-            patch_size=14,
-            embed_dim=1536,
-            num_blocks=24,
-            num_heads=12,
-            **kwargs,
-        )
+    preprocessor, trunk, head = _aim(
+        img_size=img_size,
+        patch_size=14,
+        embed_dim=1536,
+        num_blocks=24,
+        num_heads=12,
+        **kwargs,
     )
+    return AIM(preprocessor, trunk, head)
 
 
 def aim_1B(img_size: Union[int, Tuple[int, int]] = 224, **kwargs: Any) -> AIM:
-    return AIM(
-        *_aim(
-            img_size=img_size,
-            patch_size=14,
-            embed_dim=2048,
-            num_blocks=24,
-            num_heads=16,
-            **kwargs,
-        )
+    preprocessor, trunk, head = _aim(
+        img_size=img_size,
+        patch_size=14,
+        embed_dim=2048,
+        num_blocks=24,
+        num_heads=16,
+        **kwargs,
     )
+    return AIM(preprocessor, trunk, head)
 
 
 def aim_3B(
     img_size: Union[int, Tuple[int, int]] = 224, patch_size: int = 14, **kwargs: Any
 ) -> AIM:
-    return AIM(
-        *_aim(
-            img_size=img_size,
-            patch_size=patch_size,
-            embed_dim=3072,
-            num_blocks=24,
-            num_heads=24,
-            **kwargs,
-        )
+    preprocessor, trunk, head = _aim(
+        img_size=img_size,
+        patch_size=patch_size,
+        embed_dim=3072,
+        num_blocks=24,
+        num_heads=24,
+        **kwargs,
     )
+    return AIM(preprocessor, trunk, head)
 
 
 def aim_7B(
     img_size: Union[int, Tuple[int, int]] = 224, patch_size: int = 14, **kwargs: Any
 ) -> AIM:
-    return AIM(
-        *_aim(
-            img_size=img_size,
-            patch_size=patch_size,
-            embed_dim=4096,
-            num_blocks=32,
-            num_heads=32,
-            **kwargs,
-        )
+    preprocessor, trunk, head = _aim(
+        img_size=img_size,
+        patch_size=patch_size,
+        embed_dim=4096,
+        num_blocks=32,
+        num_heads=32,
+        **kwargs,
     )
+    return AIM(preprocessor, trunk, head)

--- a/hubconf.py
+++ b/hubconf.py
@@ -6,7 +6,7 @@ from torch import nn
 
 from aim import utils
 
-dependencies = ["torch"]
+dependencies = ["torch", "huggingface_hub"]
 
 
 def aim_600M(*args: Any, **kwargs: Any) -> nn.Module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 dependencies = [
     "torch>=2.0.0",
     "torchvision",
+    "huggingface_hub",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Originally proposed by @NielsRogge in #2 , this PR introduces `aim.torch.models.AIMForImageClassification`; example is below:
```python
from aim.torch.models import AIMForImageClassification
from aim.torch.data import val_transforms
from PIL import Image

img = Image.open(...)
model = AIMForImageClassification.from_pretrained("apple/aim-600M")
transform = val_transforms()

inp = transform(img).unsqueeze(0)
logits, _ = model(inp)
```

The models will be moved to the appropriate places later today.

closes #2 