### PR TITLE
Resolve TypeError in Callable Typing for Python 3.8

### DIFF
--- a/aim/utils.py
+++ b/aim/utils.py
@@ -203,7 +203,7 @@ def load_pretrained(
         return both the model and its state.
     """
 
-    def get_load_model_fn(arch: str) -> Callable[[...], Any]:
+    def get_load_model_fn(arch: str) -> Callable[..., Any]:
         if backend == "torch":
             from aim.torch import models
         elif backend == "jax":
@@ -221,7 +221,7 @@ def load_pretrained(
         }[arch]
 
     def load_state_dict(
-        loader: Callable[[str, ...], Dict[str, torch.Tensor]],
+        loader: Callable[..., Dict[str, torch.Tensor]],
         backbone_loc: str,
         head_loc: Optional[str],
     ) -> Dict[str, torch.Tensor]:


### PR DESCRIPTION
This pull request addresses the `TypeError: Callable[[arg, ...], result]: each arg must be a type. Got Ellipsis.` error while loading model in Python 3.8 (in Python 3.11 it works fine). The modification involves adjusting the type hinting in the `Callable` from the typing module.

Changes
Updated `aim/utils.py`: Replaced `Callable[[...], Any]` with `Callable[..., Any]` and `Callable[[str, ...], Dict[str, torch.Tensor]]` with `Callable[..., Dict[str, torch.Tensor]]`.